### PR TITLE
Fixing `uncaught exception` bug.

### DIFF
--- a/c3a/app/scripts/CordovaInit.js
+++ b/c3a/app/scripts/CordovaInit.js
@@ -9,7 +9,7 @@ var CordovaInit = function() {
 
 	var receivedEvent = function(event) {
 		console.log('Start event received, bootstrapping application setup.');
-		angular.bootstrap($('body'), ['c3aApp']);
+		angular.bootstrap($('body')[0], ['c3aApp']);
 	};
 	
 	this.bindEvents = function() {


### PR DESCRIPTION
`angular.bootstrap` needs an element, not a JQuery element. By adding `[0]`, we're giving the bootstrap function what it needs. Without this, I was getting `uncaught exception` from the angular framework. Fixes issue #1.
